### PR TITLE
Add support for API tokens

### DIFF
--- a/py_nightscout/api.py
+++ b/py_nightscout/api.py
@@ -38,7 +38,10 @@ class Api(object):
     def request_headers(self, api_secret: Optional[str] = None):
         headers = {"Content-Type": "application/json", "Accept": "application/json"}
         if api_secret:
-            headers["api-secret"] = hashlib.sha1(api_secret.encode("utf-8")).hexdigest()
+            if api_secret.startswith("token="):
+                headers["api-secret"] = api_secret
+            else:
+                headers["api-secret"] = hashlib.sha1(api_secret.encode("utf-8")).hexdigest()
         return headers
 
     async def get_sgvs(self, params={}) -> [SGV]:


### PR DESCRIPTION
As per [(outdated) documentation](http://www.nightscout.info/wiki/welcome/website-features/0-9-features/authentication-roles) Nightscout, besides the all-powerful API secret, supports also tokens, which can be given limited access to the API/site. This makes it possible to use them.